### PR TITLE
Better write returns

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,7 +15,6 @@ $rules = [
     'phpdoc_indent' => true,
     'phpdoc_no_package' => true,
     'phpdoc_order' => true,
-    'phpdoc_separation' => true,
     'phpdoc_single_line_var_spacing' => true,
     'phpdoc_trim' => true,
     'phpdoc_var_without_name' => true,

--- a/.php_cs
+++ b/.php_cs
@@ -14,7 +14,6 @@ $rules = [
     'phpdoc_add_missing_param_annotation' => true,
     'phpdoc_indent' => true,
     'phpdoc_no_package' => true,
-    'phpdoc_order' => true,
     'phpdoc_single_line_var_spacing' => true,
     'phpdoc_trim' => true,
     'phpdoc_var_without_name' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Write method returns a `bool`
+* `InvalidArgumentException` gets thrown if the `load` path does not exist.
 
 ## [1.0.0] - 2019-08-17
 Initial release

--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -21,8 +21,9 @@ class DotenvEditor
      * Load an values from an env file.
      *
      * @param  string  $path
-     * @throws \InvalidArgumentException
      * @return self
+     *
+     * @throws \InvalidArgumentException
      */
     public function load($path)
     {

--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -2,6 +2,7 @@
 
 namespace sixlive\DotenvEditor;
 
+use InvalidArgumentException;
 use sixlive\DotenvEditor\Support\Arr;
 
 class DotenvEditor
@@ -20,11 +21,15 @@ class DotenvEditor
      * Load an values from an env file.
      *
      * @param  string  $path
-     *
+     * @throws \InvalidArgumentException
      * @return self
      */
     public function load($path)
     {
+        if (! file_exists($path)) {
+            throw new InvalidArgumentException(sprintf('%s does not exist', $path));
+        }
+
         $this->envFile = new EnvFile($path);
 
         if ($this->envFile->isNotEmpty()) {
@@ -39,7 +44,6 @@ class DotenvEditor
      *
      * @param  string  $key
      * @param  string  $value
-     *
      * @return self
      */
     public function set($key, $value)
@@ -53,7 +57,6 @@ class DotenvEditor
      * Get all of the env values or a single value by key.
      *
      * @param  string  $key
-     *
      * @return array|string
      */
     public function getEnv($key = '')
@@ -68,23 +71,18 @@ class DotenvEditor
      * a file was loaded, it will overwrite the file that was loaded.
      *
      * @param  string  $path
-     *
-     * @return self
+     * @return bool
      */
     public function save($path = '')
     {
         if (empty($path) && $this->envFile) {
-            $this->envFile->write($this->format());
-        } else {
-            file_put_contents($path, $this->format());
+            return $this->envFile->write($this->format()) > 0;
         }
-
-        return $this;
+        return file_put_contents($path, $this->format()) !== false;
     }
 
     /**
      * Add an empty line to the config.
-     *
      * @return self
      */
     public function addEmptyLine()
@@ -99,7 +97,6 @@ class DotenvEditor
      * line before the heading.
      *
      * @param  string  $heading
-     *
      * @return self
      */
     public function heading($heading)
@@ -117,7 +114,6 @@ class DotenvEditor
      * Check if a key is defined in the env.
      *
      * @param  string  $key
-     *
      * @return bool
      */
     public function has($key)

--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -79,6 +79,7 @@ class DotenvEditor
         if (empty($path) && $this->envFile) {
             return $this->envFile->write($this->format()) > 0;
         }
+
         return file_put_contents($path, $this->format()) !== false;
     }
 

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -31,6 +31,7 @@ class EnvFile
     {
         $this->file->rewind();
         $this->file->ftruncate(0);
+
         return $this->file->fwrite($content);
     }
 

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -25,15 +25,13 @@ class EnvFile
      *
      * @param  string  $content
      *
-     * @return self
+     * @return bool
      */
     public function write($content)
     {
         $this->file->rewind();
         $this->file->ftruncate(0);
-        $this->file->fwrite($content);
-
-        return $this;
+        return $this->file->fwrite($content);
     }
 
     /**

--- a/tests/DotenvEditorTest.php
+++ b/tests/DotenvEditorTest.php
@@ -2,6 +2,7 @@
 
 namespace sixlive\DotenvEditor\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use sixlive\DotenvEditor\DotenvEditor;
 
@@ -197,5 +198,26 @@ class DotenvEditorTest extends TestCase
             file_get_contents($fixturePath)."\nFOO=bar",
             $this->path
         );
+    }
+
+    /** @test */
+    public function an_exception_is_thrown_if_the_file_does_not_exist()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $editor = new DotenvEditor;
+        $editor->load(__DIR__.'/.env');
+    }
+
+    /** @test */
+    public function returns_true_if_file_is_written()
+    {
+        $fixturePath = __DIR__.'/Fixtures/env-laravel';
+        copy($fixturePath, $this->path);
+
+        $editor = new DotenvEditor;
+        $editor->load($this->path);
+
+        $this->assertTrue($editor->save());
     }
 }


### PR DESCRIPTION
## Status
<!-- If WIP please prefix the title with [WIP] -->
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Should have better returns for writing to a file. This PR tweaks things so that writing returns a `bool`.

Loading a file should also throw an Exception if the file does not exist.

Also changes some phpdoc rules for php-cs-fixer that I didn't like.

## Related PRs
n/a

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```