### PR TITLE
Fixes Laravel APP_KEY parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Issue parsing Laravel `APP_KEY`
 
 ## [1.1.0] - 2019-08-19
 ### Changed

--- a/src/EnvFile.php
+++ b/src/EnvFile.php
@@ -86,7 +86,7 @@ class EnvFile
     private function convertLineValuesToArray()
     {
         return array_map(function ($line) {
-            return explode('=', $line);
+            return preg_split('/=/', $line, 2);
         }, $this->linesFromFile());
     }
 

--- a/tests/DotenvEditorTest.php
+++ b/tests/DotenvEditorTest.php
@@ -220,4 +220,17 @@ class DotenvEditorTest extends TestCase
 
         $this->assertTrue($editor->save());
     }
+
+    /** @test */
+    public function does_not_modify_app_key()
+    {
+        $fixturePath = __DIR__.'/Fixtures/env-laravel';
+
+        $editor = new DotenvEditor;
+        $editor->load($fixturePath);
+        $this->assertEquals(
+            'base64:LPqcjIZ3/T2pO4yrL7vgb6W/+hgyau002onyOKHvzfo=',
+            $editor->getEnv('APP_KEY')
+        );
+    }
 }

--- a/tests/Fixtures/env-laravel
+++ b/tests/Fixtures/env-laravel
@@ -1,6 +1,4 @@
-APP_NAME=Laravel
-APP_ENV=local
-APP_KEY=
+APP_KEY=base64:LPqcjIZ3/T2pO4yrL7vgb6W/+hgyau002onyOKHvzfo=
 APP_DEBUG=true
 APP_URL=http://localhost
 


### PR DESCRIPTION
## Status
<!-- If WIP please prefix the title with [WIP] -->
<!--- **READY/WIP/HOLD** --->
**READY**

## Description
Fixes an issue parsing Laravel `APP_KEY` due to the way we were splitting values on `=`.

Resolves #3 

## Related PRs
n/a

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```
