### PR TITLE
Add PHP 8 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: run-tests
 
 on:
+  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,37 @@
+name: run-tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 7.4, 7.3, 7.2, 7.1]
+        dependency-version: [prefer-lowest, prefer-stable]
+
+    name: P${{ matrix.php }} ${matrix.dependency-version}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
         php: [8.0, 7.4, 7.3, 7.2, 7.1]
         dependency-version: [prefer-lowest, prefer-stable]
 
-    name: P${{ matrix.php }} ${matrix.dependency-version}
+    name: P${{ matrix.php }} ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+phpunit.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Adds support for PHP 8
+
 ## [1.2.0] - 2019-01-31
 ### Added
 * Added a `unset` method to allow the possibily to remove a property defined in the .env file. ([#5](https://github.com/sixlive/dotenv-editor/pull/5))

--- a/README.md
+++ b/README.md
@@ -52,11 +52,7 @@ BAZ=bax
 ```
 
 ## Code Style
-In addition to the php-cs-fixer rules, StyleCI will apply the [Laravel preset](https://docs.styleci.io/presets#laravel).
-```bash
-> composer styles:lint
-> composer styles:fix
-```
+StyleCI will apply the [Laravel preset](https://docs.styleci.io/presets#laravel).
 
 ## Changelog
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": "^7.1|^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.12",
         "larapack/dd": "^1.0",
         "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
@@ -33,10 +32,6 @@
         "psr-4": {
             "sixlive\\DotenvEditor\\Tests\\": "tests"
         }
-    },
-    "scripts": {
-        "styles:lint": "vendor/bin/php-cs-fixer fix --dry-run --diff",
-        "styles:fix": "vendor/bin/php-cs-fixer fix"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": "^7.1|^7.2|^8.0"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
         "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,12 @@
         }
     ],
     "require": {
-        "php": "^7.1|^7.2"
+        "php": "^7.1|^7.2|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
         "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^7.0",
-        "sempro/phpunit-pretty-print": "^1.0.4"
+        "phpunit/phpunit": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         printerClass="Sempro\PHPUnitPrettyPrinter\PrettyPrinter">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    testdox="true"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/tests/DotenvEditorTest.php
+++ b/tests/DotenvEditorTest.php
@@ -30,8 +30,8 @@ class DotenvEditorTest extends TestCase
         $editor->set('EXAMPLE_CONFIG', 'foo');
 
         $this->assertEquals(
-           'foo',
-           $editor->getEnv('EXAMPLE_CONFIG')
+            'foo',
+            $editor->getEnv('EXAMPLE_CONFIG')
         );
     }
 
@@ -45,7 +45,7 @@ class DotenvEditorTest extends TestCase
         $editor->unset('EXAMPLE_CONFIG');
 
         $this->assertEmpty(
-           $editor->getEnv('EXAMPLE_CONFIG')
+            $editor->getEnv('EXAMPLE_CONFIG')
         );
     }
 
@@ -60,9 +60,9 @@ class DotenvEditorTest extends TestCase
         $editor->unset('EXAMPLE_CONFIG_2');
 
         $this->assertEquals(
-           ['EXAMPLE_CONFIG' => 'foo', 'EXAMPLE_CONFIG_3' => 'baz'],
-           $editor->getEnv()
-       );
+            ['EXAMPLE_CONFIG' => 'foo', 'EXAMPLE_CONFIG_3' => 'baz'],
+            $editor->getEnv()
+        );
     }
 
     /** @test */

--- a/tests/DotenvEditorTest.php
+++ b/tests/DotenvEditorTest.php
@@ -12,12 +12,12 @@ class DotenvEditorTest extends TestCase
 
     protected $path = __DIR__.'/tmp/env';
 
-    public function setUp()
+    public function setUp(): void
     {
         touch($this->path);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         array_map('unlink', glob(__DIR__.'/tmp/*'));
     }


### PR DESCRIPTION
## Status
READY

## Description
I've updated the dependencies for PHP 8 support.

This comes with the caveat that php-cs-fixer support has been removed, because it doesn't yet [run on PHP 8](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702).

I've also added GitHub Actions, so we know everything works from PHP 7.1 right through PHP 8.0.

## Related PRs
None

## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
N/A