### PR TITLE
Wrap added values to protect against special chars

### DIFF
--- a/src/DotenvEditor.php
+++ b/src/DotenvEditor.php
@@ -13,6 +13,11 @@ class DotenvEditor
     protected $env = [];
 
     /**
+     * @var array
+     */
+    protected $tracked = [];
+
+    /**
      * @var \sixlive\DotenvEditor\EnvFile
      */
     protected $envFile;
@@ -50,6 +55,7 @@ class DotenvEditor
     public function set($key, $value)
     {
         $this->env[$key] = $value;
+        $this->tracked[] = $key;
 
         return $this;
     }
@@ -151,6 +157,12 @@ class DotenvEditor
     private function format()
     {
         $valuePairs = Arr::mapWithKeys($this->env, function ($item, $key) {
+            // If we are adding the key we should wrap the contents to prevent
+            // any special characters from leaking through.
+            if (in_array($key, $this->tracked)) {
+                return sprintf('%s="%s"', $key, $item);
+            }
+
             return is_string($key)
                 ? sprintf('%s=%s', $key, $item)
                 : $item;

--- a/tests/DotenvEditorTest.php
+++ b/tests/DotenvEditorTest.php
@@ -74,7 +74,7 @@ class DotenvEditorTest extends TestCase
         $editor->set('EXAMPLE_CONFIG', 'foo');
         $editor->save();
 
-        $this->assertFileContents('EXAMPLE_CONFIG=foo', $this->path);
+        $this->assertFileContents('EXAMPLE_CONFIG="foo"', $this->path);
     }
 
     /** @test */
@@ -87,7 +87,7 @@ class DotenvEditorTest extends TestCase
         $editor->set('EXAMPLE_CONFIG', 'foo');
         $editor->save($newPath);
 
-        $this->assertFileContents('EXAMPLE_CONFIG=foo', $newPath);
+        $this->assertFileContents('EXAMPLE_CONFIG="foo"', $newPath);
     }
 
     /** @test */
@@ -103,7 +103,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            "EXAMPLE_CONFIG=foo\nEXAMPLE_CONFIG_2=bar",
+            "EXAMPLE_CONFIG=\"foo\"\nEXAMPLE_CONFIG_2=\"bar\"",
             $this->path
         );
     }
@@ -120,7 +120,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            "EXAMPLE_CONFIG=foo\n\nEXAMPLE_CONFIG_2=bar",
+            "EXAMPLE_CONFIG=\"foo\"\n\nEXAMPLE_CONFIG_2=\"bar\"",
             $this->path
         );
     }
@@ -136,7 +136,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            "# Examples\nEXAMPLE_CONFIG=foo",
+            "# Examples\nEXAMPLE_CONFIG=\"foo\"",
             $this->path
         );
     }
@@ -155,7 +155,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            "APP_KEY=bar\n\n# Examples\nEXAMPLE_CONFIG=foo",
+            "APP_KEY=\"bar\"\n\n# Examples\nEXAMPLE_CONFIG=\"foo\"",
             $this->path
         );
     }
@@ -199,7 +199,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            "EXAMPLE=bar\n\n# Section\nEXAMPLE_3=bar\n\n# Foo\nFOO=bar",
+            "EXAMPLE=bar\n\n# Section\nEXAMPLE_3=bar\n\n# Foo\nFOO=\"bar\"",
             $this->path
         );
     }
@@ -217,7 +217,7 @@ class DotenvEditorTest extends TestCase
         $editor->save();
 
         $this->assertFileContents(
-            file_get_contents($fixturePath)."\nFOO=bar",
+            file_get_contents($fixturePath)."\nFOO=\"bar\"",
             $this->path
         );
     }


### PR DESCRIPTION
## Description
Rather than checking for special characters and other edge cases, we should wrap and mutated or added values in `"` quotes.

Resolves #9 